### PR TITLE
Switch ShortHash invocation to DynamicMethod

### DIFF
--- a/Source/Utils/InjectedDefHasher.cs
+++ b/Source/Utils/InjectedDefHasher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Reflection.Emit;
 using Verse;
 
 namespace HugsLib.Utils {
@@ -7,14 +8,27 @@ namespace HugsLib.Utils {
 	/// Adds a hash to a manually instantiated def to avoid def collisions.
 	/// </summary>
 	public static class InjectedDefHasher {
-		private static MethodInfo giveShortHashMethod;
-
+        private static Action<Def, Type> GiveShortHash;
+				
 		internal static void PrepareReflection() {
-			giveShortHashMethod = typeof(ShortHashGiver).GetMethod("GiveShortHash", BindingFlags.NonPublic | BindingFlags.Static, null, new[] { typeof(Def), typeof(Type) }, null);
+            Type[] parametersSignature = new[] {typeof(Def), typeof(Type)};
+						
+			MethodInfo giveShortHashMethod = typeof(ShortHashGiver).GetMethod("GiveShortHash", BindingFlags.NonPublic | BindingFlags.Static, null, parametersSignature, null);
 			if (giveShortHashMethod == null) {
 				HugsLibController.Logger.Error("Failed to reflect ShortHashGiver.GiveShortHash");
+			    return;
 			}
-		}
+			
+			DynamicMethod dm = new DynamicMethod("__GiveShortHash_Dynamic", null, parametersSignature, typeof(ShortHashGiver));		// logically associate new method with 'ShortHashGiver' type
+            ILGenerator IL = dm.GetILGenerator();
+            IL.Emit(OpCodes.Ldarg_0);                               // 'Def' argument
+            IL.Emit(OpCodes.Ldarg_1);                               // 'Type' argument
+            IL.Emit(OpCodes.Call, giveShortHashMethod);             // call 'ShortHashGiver.GiveShortHash'
+            IL.Emit(OpCodes.Ret);                                   // return
+			
+			GiveShortHash = (Action<Def, Type>) dm.CreateDelegate(typeof(Action<Def, Type>));	
+		}			
+		
 
 		/// <summary>
 		/// Give a short hash to a def created at runtime.
@@ -23,8 +37,8 @@ namespace HugsLib.Utils {
 		/// <param name="newDef"></param>
 		/// <param name="defType">The type of defs your def will be saved with. For example, use typeof(ThingDef) if your def extends ThingDef.</param>
 		public static void GiveShortHasToDef(Def newDef, Type defType) {
-			if(giveShortHashMethod == null) throw new Exception("Hasher not initalized");
-			giveShortHashMethod.Invoke(null, new object[] { newDef, defType });
+			if(GiveShortHash == null) throw new Exception("Hasher not initalized");
+		    GiveShortHash(newDef, defType);
 		}
 	}
 }


### PR DESCRIPTION
I took a peek at the short hash invocation in HugsLib.

Current code just uses Reflection. This is __by far__ the slowest method of code invocation. Switching this to a DynamicMethod should give orders of magnitude better performance (Quick google of available comparisons found http://www.ookii.org/Blog/reflection_vs_dynamic_code_generation).

Compilation goes through (didn't run any tests though), but I had an identical version to this code running perfectly fine in an unfinished mod (which I switched to HugsLib, where I found the simple reflection code).

