### PR TITLE
Fix for Dialog_Options null pointer exception

### DIFF
--- a/Source/HugsLibController.cs
+++ b/Source/HugsLibController.cs
@@ -58,7 +58,8 @@ namespace HugsLib {
 
 		// most of the initialization happens during Verse.Mod instantiation. Pretty much no vanilla data is yet loaded at this point.
 		internal static void EarlyInitialize() {
-			try {
+			try
+			{
 				if (earlyInitializationCompleted) {
 					Logger.Warning("Attempted repeated early initialization of controller: " + Environment.StackTrace);
 					return;

--- a/Source/Settings/OptionsDialogExtensions.cs
+++ b/Source/Settings/OptionsDialogExtensions.cs
@@ -18,13 +18,13 @@ internal static class OptionsDialogExtensions {
 		var hugsLibEntries = HugsLibController.Instance.Settings.ModSettingsPacks
 			.Where(p =>
 			{
-				if (p.Handles.All(h => !h.NeverVisible))
+				if (p.Handles.All(h => h.NeverVisible))
 				{
 					return false;
 				}
-				if (!modLookup.ContainsKey(p.ModId))
+				if (!modLookup.ContainsKey(p.EntryName))
 				{
-					Log.Warning($"[HugsLib]: ModId not found in mod list, does it not match the name?");
+					Log.Warning($"[HugsLib]: mod EntryName not found in mod list, does it not match the name? {p.EntryName}");
 					return false;
 				}
 
@@ -35,7 +35,7 @@ internal static class OptionsDialogExtensions {
 					? "HugsLib_setting_unnamed_mod".Translate().ToString()
 					: pack.EntryName;
 
-				return new SettingsProxyMod(label, pack, modLookup[pack.ModId]);
+				return new SettingsProxyMod(label, pack, modLookup[pack.EntryName]);
 			});
 		var combinedEntries = stockEntries
 			.Concat(hugsLibEntries)

--- a/Source/Settings/OptionsDialogExtensions.cs
+++ b/Source/Settings/OptionsDialogExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using HarmonyLib;
 using HugsLib.Utils;
 using JetBrains.Annotations;
 using RimWorld;
@@ -18,7 +17,6 @@ internal static class OptionsDialogExtensions {
 	public static void InjectHugsLibModEntries(Dialog_Options dialog) {
 		var stockEntries = (IEnumerable<Mod>)cachedModsField.GetValue(dialog);
 		var modLookup = LoadedModManager.RunningMods.ToDictionary(m => m.Name, m => m);
-		FileLog.Log($"modLookup: {modLookup.Select(kp => $"{kp.Key}: {kp.Value}").Join(",")}");
 		var hugsLibEntries = HugsLibController.Instance.Settings.ModSettingsPacks
 			.Where(p => p.Handles.Any(h => !h.NeverVisible) && modLookup.ContainsKey(p.ModId))
 			.Select(pack => {

--- a/Source/Settings/OptionsDialogExtensions.cs
+++ b/Source/Settings/OptionsDialogExtensions.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using HugsLib.Utils;
 using JetBrains.Annotations;
 using RimWorld;
 using Verse;

--- a/Source/Settings/OptionsDialogExtensions.cs
+++ b/Source/Settings/OptionsDialogExtensions.cs
@@ -16,7 +16,20 @@ internal static class OptionsDialogExtensions {
 		var stockEntries = (IEnumerable<Mod>)cachedModsField.GetValue(dialog);
 		var modLookup = LoadedModManager.RunningMods.ToDictionary(m => m.Name, m => m);
 		var hugsLibEntries = HugsLibController.Instance.Settings.ModSettingsPacks
-			.Where(p => p.Handles.Any(h => !h.NeverVisible) && modLookup.ContainsKey(p.ModId))
+			.Where(p =>
+			{
+				if (p.Handles.All(h => !h.NeverVisible))
+				{
+					return false;
+				}
+				if (!modLookup.ContainsKey(p.ModId))
+				{
+					Log.Warning($"[HugsLib]: ModId not found in mod list, does it not match the name?");
+					return false;
+				}
+
+				return true;
+			})
 			.Select(pack => {
 				var label = pack.EntryName.NullOrEmpty()
 					? "HugsLib_setting_unnamed_mod".Translate().ToString()


### PR DESCRIPTION
fixes #90 #93 

related #94 but that one seems to be missing a commit or something as it doesn't actually change `SettingsModProxy` which is the issue that causes the exception. This takes a slightly different approach and matches the mod content packs up with the settings packs on-the-fly when it does the injection. I'm not sure what performance implications this has, I haven't benchmarked it

I have tested it with my current modlist (168 strong) and it appears to work with no issues