### PR TITLE
1.5 moved these calls elsewhere, hugslib's copied method should too

### DIFF
--- a/Source/Quickstart/QuickstartController.cs
+++ b/Source/Quickstart/QuickstartController.cs
@@ -217,8 +217,6 @@ namespace HugsLib.Quickstart {
 			Find.GameInitData.ChooseRandomStartingTile();
 			Find.GameInitData.mapSize = Settings.MapSizeToGen;
 			Find.Scenario.PostIdeoChosen();
-			Find.GameInitData.PrepForMapGen();
-			Find.Scenario.PreMapGenerate();
 		}
 
 		private static Scenario TryGetScenarioByName(string name) {


### PR DESCRIPTION
Some map set up calls were moved out of quickstart method, and called elsewhere -- now HugsLib quickstarts create two world objects for starting colony, and one is broke.

So, just need to removed this like vanilla code odes